### PR TITLE
Navigate to chat page after login 

### DIFF
--- a/DeeperSeek/DeeperSeek.py
+++ b/DeeperSeek/DeeperSeek.py
@@ -121,7 +121,7 @@ class DeepSeek:
         )
 
         self.logger.debug("Navigating to the main page...")
-        chat_url = "https://chat.deepseek.com/"
+        chat_url = "https://chat.deepseek.com/" if not self._chat_id else f"https://chat.deepseek.com/a/chat/s/{self._chat_id}"
         await self.browser.get(chat_url)
         self.logger.debug(f"Navigated to: {chat_url}")
 
@@ -235,8 +235,7 @@ class DeepSeek:
                 if not token_failed else "Both token and email/password are incorrect")
 
         self.logger.debug(f"Logged in successfully using email and password! {'(Token method failed)' if token_failed else ''}")
-    
-        self.logger.debug("Navigating to the chat page...")
+        self.logger.debug("Navigating to the main page...")
         chat_url = "https://chat.deepseek.com/" if not self._chat_id else f"https://chat.deepseek.com/a/chat/s/{self._chat_id}"
         await self.browser.get(chat_url)
         self.logger.debug(f"Navigated to: {chat_url}")

--- a/DeeperSeek/DeeperSeek.py
+++ b/DeeperSeek/DeeperSeek.py
@@ -120,9 +120,10 @@ class DeepSeek:
             headless = self._headless
         )
 
-        self.logger.debug("Navigating to the chat page...")
-        await self.browser.get("https://chat.deepseek.com/" if not self._chat_id \
-            else f"https://chat.deepseek.com/a/chat/s/{self._chat_id}")
+        self.logger.debug("Navigating to the main page...")
+        chat_url = "https://chat.deepseek.com/"
+        await self.browser.get(chat_url)
+        self.logger.debug(f"Navigated to: {chat_url}")
 
         if self._attempt_cf_bypass:
             try:
@@ -235,6 +236,12 @@ class DeepSeek:
 
         self.logger.debug(f"Logged in successfully using email and password! {'(Token method failed)' if token_failed else ''}")
     
+        self.logger.debug("Navigating to the chat page...")
+        chat_url = "https://chat.deepseek.com/" if not self._chat_id else f"https://chat.deepseek.com/a/chat/s/{self._chat_id}"
+        await self.browser.get(chat_url)
+        self.logger.debug(f"Navigated to: {chat_url}")
+
+
     async def _dev_debug(self) -> None:
         """A method for debugging purposes.
         


### PR DESCRIPTION
**Issue**
It seems that after logged in with Email and Password
The browser page will go back to the main page (where users start a new chat)
Thus, it cannot continue the conversation in the existing chat even if a chat id is provided.

**Fix**
Added some line of codes to navigate back to the chat page after login.
Also adding some logs to have more visibility on where the browser page is on 

**Test**   
Tested on my computer with my updated fork