### PR TITLE
 Rewrite method of getting the response text

### DIFF
--- a/DeeperSeek/DeeperSeek.py
+++ b/DeeperSeek/DeeperSeek.py
@@ -540,8 +540,7 @@ class DeepSeek:
 
         self.logger.debug("Extracting the response text...")
         soup = BeautifulSoup(repr(response_generated[-1]), 'html.parser')
-        markdown_blocks = soup.find_all("div", class_ = "ds-markdown ds-markdown--block")
-        response_text = "\n\n".join(get_text(str(block)).strip() for block in markdown_blocks)
+        response_text = str(await self.browser.main_tab.evaluate("document.querySelectorAll('.ds-markdown.ds-markdown--block').values().map((r => { for (p in r.parentElement) if (p.startsWith('__reactFiber$')) return r.parentElement[p].pendingProps.children[3].props.markdown })).toArray().join(' ');"))
 
         if response_text.lower() == "the server is busy. please try again later.":
             raise ServerDown("The server is busy. Please try again later.")


### PR DESCRIPTION
The old method of getting the response text had some problems:

- Plain text, no Markdown, formatting and styling at all
- It did copy the text of code block copy button. 
![image](https://github.com/user-attachments/assets/e2614097-fe8c-4893-b549-9ea292517f1c) 
Response looked like this: 
`json         Copy               {"field": "value"}`



So, I rewrote it using injection of small JS script that gets response text from hidden React fields. 
Now, response text is the same as the one we get when pressing copy icon button on web site. Something like this: 
```
```json
{
  "field": "value"
}
``` 